### PR TITLE
Updated to android 10 and latest build tools

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.3.60'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/cyanBat/build.gradle
+++ b/cyanBat/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         applicationId "at.smiech.cyanbat"
         minSdkVersion 17
-        targetSdkVersion 28
+        targetSdkVersion 29
     }
 
     buildTypes {
@@ -25,9 +25,9 @@ android {
 
 dependencies {
     implementation project(':gameFramework')
-    implementation 'androidx.appcompat:appcompat:1.0.2'
-    implementation "androidx.core:core-ktx:+"
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation "androidx.core:core-ktx:1.1.0"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 }
 repositories {
     mavenCentral()

--- a/cyanBat/src/main/AndroidManifest.xml
+++ b/cyanBat/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.VIBRATE" />
 
     <application
+        android:allowBackup="false"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Theme.AppCompat.NoActionBar">
@@ -39,14 +40,21 @@
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/in_game"
             android:screenOrientation="landscape" />
-        <activity android:name=".activities.CreditsActivity"
+        <activity
+            android:name=".activities.CreditsActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/credits"
             android:screenOrientation="landscape" />
-        <activity android:name=".activities.GameOptionsActivity"
+        <activity
+            android:name=".activities.GameOptionsActivity"
             android:configChanges="orientation|screenSize|keyboardHidden"
             android:label="@string/settings"
             android:screenOrientation="landscape" />
+
+        <provider
+            android:name=".persistence.ScoreProvider"
+            android:authorities="at.smiech.cyanbat"
+            android:exported="false" />
     </application>
 
 </manifest>

--- a/cyanBat/src/main/java/at/smiech/cyanbat/persistence/ScoreProvider.kt
+++ b/cyanBat/src/main/java/at/smiech/cyanbat/persistence/ScoreProvider.kt
@@ -24,7 +24,7 @@ class ScoreProvider : ContentProvider() {
     private var sqLiteHelper: CyanBatSQLiteHelper? = null
 
     override fun onCreate(): Boolean {
-        this.sqLiteHelper = CyanBatSQLiteHelper(context)
+        this.sqLiteHelper = CyanBatSQLiteHelper(context!!)
         return true
     }
 

--- a/gameFramework/build.gradle
+++ b/gameFramework/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 28
-    buildToolsVersion '28.0.3'
+    compileSdkVersion 29
+    buildToolsVersion '29.0.2'
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 28
+        targetSdkVersion 29
         compileOptions {
             sourceCompatibility JavaVersion.VERSION_1_8
             targetCompatibility JavaVersion.VERSION_1_8
@@ -25,5 +25,5 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.0.2'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
 }


### PR DESCRIPTION
Updated android target to api level 29 i.e. android Q/10. Updated Kotlin to 1.3.60. Changed kotlin standard lib to latest jdk8 based version. Updated android build tools gradle to 3.5.2. Updated android build tools to 29.0.2 to match android 10. Updated appcompat and androidx core to 1.1.0. Also registered the score provider in manifest. Set allowBackup in manifest to false. Minor reformat of manifest.